### PR TITLE
dlerror,freebsd: call dlerror only if necessary

### DIFF
--- a/src/unix/dl.c
+++ b/src/unix/dl.c
@@ -53,7 +53,7 @@ void uv_dlclose(uv_lib_t* lib) {
 int uv_dlsym(uv_lib_t* lib, const char* name, void** ptr) {
   dlerror(); /* Reset error status. */
   *ptr = dlsym(lib->handle, name);
-  return uv__dlerror(lib);
+  return *ptr ? 0 : uv__dlerror(lib);
 }
 
 


### PR DESCRIPTION
Similar to the dlopen codepath.

Older FreeBSD sometimes concurrently sets or clears this variable from other threads inside the libc they use. There was thus no way to ever use dlerror safely there. Julia does not use these libuv wrapper calls, so I forgot about it here, but we reported upstream, and looks like it is fixed now (https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=95339), so this PR is only about supporting old FreeBSD versions better.

Refs: https://github.com/JuliaLang/julia/pull/40392
Refs: https://github.com/JuliaLang/julia/issues/39582