### PR TITLE
build: add iOS to macos CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,6 +79,13 @@ jobs:
       - name: Test
         run: |
           cd build && ctest -V
+      - name: Build iOS
+        run: |
+          mkdir build-ios
+          cd build-ios
+          cmake .. -GXcode -DCMAKE_SYSTEM_NAME:STRING=iOS -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED:BOOL=NO -DCMAKE_CONFIGURATION_TYPES:STRING=Release
+          cmake --build . || true # XXX: allow failure
+          ls -lh
 
   build-cross-qemu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Smokescreen for build errors on iOS, currently ignoring failures due to
aforementioned build errors.